### PR TITLE
remove node_modules from .vscodeignore file

### DIFF
--- a/extensions/vscode/.vscodeignore
+++ b/extensions/vscode/.vscodeignore
@@ -6,9 +6,3 @@
 **/tsconfig.base.json
 contributing.md
 .travis.yml
-node_modules/**
-!node_modules/vscode-jsonrpc/**
-!node_modules/vscode-languageclient/**
-!node_modules/vscode-languageserver-protocol/**
-!node_modules/vscode-languageserver-types/**
-!node_modules/semver/**


### PR DESCRIPTION
Hi,

really cool project! The vscode extension build from the current master seems to be broken.
The vsix file does not include the required node_modules (see the nightly vsix for an example)
and fails to load. I am not sure if it is the right fix (as I have basically zero experience
with this type of code) but removing the respective ignores seems to do the trick.

Best regards,
Mario
