### PR TITLE
Fix CI by specifying vsce version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
               working-directory: extensions/vscode
               run: |
                   npm install
-                  npm install -g vsce
+                  npm install -g vsce@1.103.1
                   vsce package -o veridian.vsix
 
     lints:
@@ -186,7 +186,7 @@ jobs:
               working-directory: extensions/vscode
               run: |
                   npm install
-                  npm install -g vsce
+                  npm install -g vsce@1.103.1
                   vsce package -o veridian.vsix
 
             - uses: actions/upload-artifact@v2


### PR DESCRIPTION
CI is failing for the extension packaging step since November 2021. Back then, a new vsce version was released, requiring nodejs > 14. https://github.com/microsoft/vscode-vsce/releases/tag/v2.0.0

This commit explicitly specifyies the version before this major change, for compatibility reasons.