### PR TITLE
Add Emacs config section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ In `coc-settings.json`:
 
 ```
 
+### Emacs
+
+- Install the [`verilog-ext`](https://github.com/gmlarumbe/verilog-ext/) package
+- Copy the following snippet into your init file:
+
+```elisp
+(require 'verilog-ext)
+(verilog-ext-mode-setup)
+(verilog-ext-eglot-set-server 've-veridian) ;`eglot' config
+(verilog-ext-lsp-set-server 've-veridian)   ; `lsp' config
+```
+
 The [full list](https://github.com/vivekmalneedi/veridian/wiki/Usage-Instructions-for-various-LSP-Clients) is on the wiki and includes configuration for the neovim built-in lsp client
 
 ## Configuration


### PR DESCRIPTION
This language server can be easily configured for Emacs also through the [`verilog-ext`](https://github.com/gmlarumbe/verilog-ext/) extension package.

It supports Emacs builtin `eglot` client as well as `lsp-mode`.